### PR TITLE
Fix + refactor `file-max-size` rule in combination with `include-empty-lines` and/or `include-comments`

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -34,7 +34,8 @@ Avoid files with more than 200 lines:
 "file-max-size": {
   "max-lines": 200,
   "include-comments": true,
-  "include-empty-lines": true
+  "include-empty-lines": true,
+  "include-brackets": true
 },
 ```
 

--- a/src/default.readable.json
+++ b/src/default.readable.json
@@ -19,7 +19,8 @@
     "file-max-size": {
       "max-lines": 200,
       "include-comments": true,
-      "include-empty-lines": true
+      "include-empty-lines": true,
+      "include-brackets": true
     },
     "argument-override": {
       "allow-pass-by-reference": true

--- a/src/line-count.js
+++ b/src/line-count.js
@@ -1,0 +1,56 @@
+const {types} = require('./tokenize');
+
+function countLines(tokens, {comments, emptyLines}) {
+  // Count empty lines
+  const typesPerLine = tokens.array.reduce((acc, token) => {
+    const group = (acc[token.line] || []);
+    group.push(token.type);
+    return { ...acc, [token.line]: group };
+  }, {});
+
+  let emptyLineCount = Object.values(typesPerLine)
+    .filter((typesOnLine) => typesOnLine.every((tokenType) => tokenType === types.whitespace))
+    .length;
+
+  // Ignore new lines after block comments
+  const lineNumbers = Object.keys(typesPerLine).sort();
+  for (let i = 1; i < lineNumbers.length; i += 1) {
+    const previousLine = typesPerLine[lineNumbers[i - 1]];
+    const currentLine = typesPerLine[lineNumbers[i]];
+    const prevLineIsComment = previousLine.every((tokenType) => tokenType === types.comment);
+    const curLineIsWhitespace = currentLine.every((tokenType) => tokenType === types.whitespace);
+    // Current line contains the new line for the block comment. So, this is not an empty line.
+    if (prevLineIsComment && curLineIsWhitespace) {
+      emptyLineCount -= 1;
+    }
+  }
+  const lines = new Set();
+  while (tokens.type() !== types.eof) {
+    tokens.body().split(/\r?\n/).forEach((_, i) => {
+      if (tokens.type() === types.whitespace) {
+        return;
+      }
+      if (tokens.type() === types.comment && !comments) {
+        return;
+      }
+      lines.add(tokens.current().line + i);
+    });
+    tokens.step(false, comments || emptyLines);
+  }
+
+  tokens.step(true);
+  let lineCount = tokens.current().line;
+  if (!emptyLines || !comments) {
+    lineCount = lines.size;
+    if (emptyLines) {
+      lineCount += emptyLineCount;
+    }
+  }
+
+  return {
+    lineCount,
+    currentToken: tokens.current(),
+  };
+}
+
+module.exports = countLines;

--- a/src/line-count.js
+++ b/src/line-count.js
@@ -1,12 +1,18 @@
 const { types } = require('./tokenize');
 
-function countLines(tokens, { comments, emptyLines }) {
+function countLines(startToken, endToken, { comments, emptyLines, brackets }) {
+  const tokens = startToken.copy();
+
   // Count empty lines
-  const typesPerLine = tokens.array.reduce((acc, token) => {
-    const group = (acc[token.line] || []);
-    group.push(token.type);
-    return { ...acc, [token.line]: group };
-  }, {});
+  let typesPerLine = {};
+  const tokenIterator = startToken.copy();
+  while (tokenIterator.pos !== endToken.pos) {
+    const currentLine = tokenIterator.current().line;
+    const group = (typesPerLine[currentLine] || []);
+    group.push(tokenIterator.current().type);
+    typesPerLine = { ...typesPerLine, [currentLine]: group };
+    tokenIterator.step(false, true);
+  }
 
   let emptyLineCount = Object.values(typesPerLine)
     .filter((typesOnLine) => typesOnLine.every((tokenType) => tokenType === types.whitespace))
@@ -27,12 +33,15 @@ function countLines(tokens, { comments, emptyLines }) {
 
   // Count lines including empty lines. Excludes comments if `include-comments` is falsy.
   const lines = new Set();
-  while (tokens.type() !== types.eof) {
+  while (tokens.pos !== endToken.pos) {
     tokens.body().split(/\r?\n/).forEach((_, i) => {
       if (tokens.type() === types.whitespace) {
         return;
       }
       if (tokens.type() === types.comment && !comments) {
+        return;
+      }
+      if ((tokens.type() === types.bracket && !brackets)) {
         return;
       }
       lines.add(tokens.current().line + i);
@@ -42,8 +51,8 @@ function countLines(tokens, { comments, emptyLines }) {
 
   // Count the total amount of lines based on the settings
   tokens.step(true);
-  let lineCount = tokens.current().line;
-  if (!emptyLines || !comments) {
+  let lineCount = tokens.current().line - startToken.current().line + 1; // +1 to include the first line.
+  if (!emptyLines || !comments || !brackets) {
     lineCount = lines.size;
     if (emptyLines) {
       lineCount += emptyLineCount;

--- a/src/line-count.js
+++ b/src/line-count.js
@@ -33,7 +33,7 @@ function countLines(startToken, endToken, { comments, emptyLines }) {
 
   // Count lines including empty lines. Excludes comments if `include-comments` is falsy.
   const lines = new Set();
-  while (tokens.pos !== endToken.pos) {
+  while (tokens.pos <= endToken.pos && tokens.type() !== types.eof) {
     tokens.body().split(/\r?\n/).forEach((_, i) => {
       if (tokens.type() === types.whitespace) {
         return;

--- a/src/line-count.js
+++ b/src/line-count.js
@@ -1,6 +1,6 @@
 const { types } = require('./tokenize');
 
-function countLines(startToken, endToken, { comments, emptyLines }) {
+function countLines(startToken, endToken, { comments, emptyLines, brackets }) {
   const tokens = startToken.copy();
 
   // Count empty lines
@@ -48,6 +48,9 @@ function countLines(startToken, endToken, { comments, emptyLines }) {
       if (tokens.type() === types.comment && !comments) {
         return;
       }
+      if ((tokens.type() === types.bracket && !brackets)) {
+        return;
+      }
       lines.add(tokens.current().line + i);
     });
     tokens.step(false, comments || emptyLines);
@@ -59,7 +62,7 @@ function countLines(startToken, endToken, { comments, emptyLines }) {
   // Count the total amount of lines based on the settings
   // +1 to include the first line.
   let lineCount = tokens.current().line - startToken.current().line + 1;
-  if (!emptyLines || !comments) {
+  if (!emptyLines || !comments || !brackets) {
     lineCount = lines.size;
     if (emptyLines) {
       lineCount += emptyLineCount;

--- a/src/line-count.js
+++ b/src/line-count.js
@@ -6,30 +6,37 @@ function countLines(startToken, endToken, { comments, emptyLines }) {
   // Count empty lines
   let typesPerLine = {};
   const tokenIterator = startToken.copy();
-  while (tokenIterator.pos !== endToken.pos) {
-    const currentLine = tokenIterator.current().line;
+  let emptyLineCount = 0;
+  let previousToken = null;
+  let currentToken = tokenIterator.current();
+  while (tokenIterator.pos <= endToken.pos && tokens.type() !== types.eof) {
+    const currentLine = currentToken.line;
+
+    // Update types per line
     const group = (typesPerLine[currentLine] || []);
     group.push(tokenIterator.current().type);
     typesPerLine = { ...typesPerLine, [currentLine]: group };
-    tokenIterator.step(false, true);
-  }
 
-  let emptyLineCount = Object.values(typesPerLine)
-    .filter((typesOnLine) => typesOnLine.every((tokenType) => tokenType === types.whitespace))
-    .length;
-
-  // Ignore new lines after block comments
-  const lineNumbers = Object.keys(typesPerLine).sort();
-  for (let i = 1; i < lineNumbers.length; i += 1) {
-    const previousLine = typesPerLine[lineNumbers[i - 1]];
-    const currentLine = typesPerLine[lineNumbers[i]];
-    const prevLineIsComment = previousLine.every((tokenType) => tokenType === types.comment);
-    const curLineIsWhitespace = currentLine.every((tokenType) => tokenType === types.whitespace);
-    // Current line contains the new line for the block comment. So, this is not an empty line.
-    if (prevLineIsComment && curLineIsWhitespace) {
+    // If a comment is followed with a newline on a future line number.
+    // The comment ends on that line. Therefore, the future line is not an empty line.
+    // And we cannot count this for our empty line count.
+    const isDiffLine = previousToken && previousToken.line !== currentToken.line;
+    const currentIsNewLine = currentToken.body === '\n' || currentToken.body === '\r';
+    const previousIsComment = previousToken && previousToken.type === types.comment;
+    if (isDiffLine && previousIsComment && currentIsNewLine) {
       emptyLineCount -= 1;
     }
+
+    // Step through iterator and update variables
+    tokenIterator.step(false, true);
+    previousToken = currentToken;
+    currentToken = tokenIterator.current();
   }
+
+  // Empty lines are lines which contain only whitespaces
+  emptyLineCount += Object.values(typesPerLine)
+    .filter((typesOnLine) => typesOnLine.every((tokenType) => tokenType === types.whitespace))
+    .length;
 
   // Count lines including empty lines. Excludes comments if `include-comments` is falsy.
   const lines = new Set();

--- a/src/line-count.js
+++ b/src/line-count.js
@@ -1,6 +1,6 @@
-const {types} = require('./tokenize');
+const { types } = require('./tokenize');
 
-function countLines(tokens, {comments, emptyLines}) {
+function countLines(tokens, { comments, emptyLines }) {
   // Count empty lines
   const typesPerLine = tokens.array.reduce((acc, token) => {
     const group = (acc[token.line] || []);

--- a/src/line-count.js
+++ b/src/line-count.js
@@ -1,6 +1,6 @@
 const { types } = require('./tokenize');
 
-function countLines(startToken, endToken, { comments, emptyLines, brackets }) {
+function countLines(startToken, endToken, { comments, emptyLines }) {
   const tokens = startToken.copy();
 
   // Count empty lines
@@ -41,9 +41,6 @@ function countLines(startToken, endToken, { comments, emptyLines, brackets }) {
       if (tokens.type() === types.comment && !comments) {
         return;
       }
-      if ((tokens.type() === types.bracket && !brackets)) {
-        return;
-      }
       lines.add(tokens.current().line + i);
     });
     tokens.step(false, comments || emptyLines);
@@ -51,8 +48,9 @@ function countLines(startToken, endToken, { comments, emptyLines, brackets }) {
 
   // Count the total amount of lines based on the settings
   tokens.step(true);
-  let lineCount = tokens.current().line - startToken.current().line + 1; // +1 to include the first line.
-  if (!emptyLines || !comments || !brackets) {
+  // +1 to include the first line.
+  let lineCount = tokens.current().line - startToken.current().line + 1;
+  if (!emptyLines || !comments) {
     lineCount = lines.size;
     if (emptyLines) {
       lineCount += emptyLineCount;

--- a/src/line-count.js
+++ b/src/line-count.js
@@ -46,8 +46,10 @@ function countLines(startToken, endToken, { comments, emptyLines }) {
     tokens.step(false, comments || emptyLines);
   }
 
+  if (tokens.current().type === types.eof) {
+    tokens.step(true);
+  }
   // Count the total amount of lines based on the settings
-  tokens.step(true);
   // +1 to include the first line.
   let lineCount = tokens.current().line - startToken.current().line + 1;
   if (!emptyLines || !comments) {

--- a/src/line-count.js
+++ b/src/line-count.js
@@ -24,6 +24,8 @@ function countLines(tokens, { comments, emptyLines }) {
       emptyLineCount -= 1;
     }
   }
+
+  // Count lines including empty lines. Excludes comments if `include-comments` is falsy.
   const lines = new Set();
   while (tokens.type() !== types.eof) {
     tokens.body().split(/\r?\n/).forEach((_, i) => {
@@ -38,6 +40,7 @@ function countLines(tokens, { comments, emptyLines }) {
     tokens.step(false, comments || emptyLines);
   }
 
+  // Count the total amount of lines based on the settings
   tokens.step(true);
   let lineCount = tokens.current().line;
   if (!emptyLines || !comments) {

--- a/src/rules/file-max-size.js
+++ b/src/rules/file-max-size.js
@@ -7,8 +7,12 @@ module.exports = {
     const maxLines = oldConfig ? options : options['max-lines'];
     const comments = oldConfig ? true : options['include-comments'];
     const emptyLines = oldConfig ? true : options['include-empty-lines'];
+    let brackets = oldConfig ? true : options['include-brackets'];
+    if (brackets === undefined) {
+      brackets = true; // Backwards compatibility
+    }
 
-    const settings = { comments, emptyLines };
+    const settings = { comments, emptyLines, brackets };
     const startToken = tokens.copy();
     const endToken = tokens.copy().stepToEof();
     const { lineCount, currentToken } = countLines(startToken, endToken, settings);

--- a/src/rules/file-max-size.js
+++ b/src/rules/file-max-size.js
@@ -1,4 +1,3 @@
-/* eslint no-continue: off */
 const countLines = require('../line-count');
 
 module.exports = {
@@ -8,8 +7,15 @@ module.exports = {
     const maxLines = oldConfig ? options : options['max-lines'];
     const comments = oldConfig ? true : options['include-comments'];
     const emptyLines = oldConfig ? true : options['include-empty-lines'];
+    let brackets = oldConfig ? true : options['include-brackets'];
+    if (brackets === undefined) {
+      brackets = true; // Backwards compatibility
+    }
 
-    const { lineCount, currentToken } = countLines(tokens.copy(), { comments, emptyLines });
+    const settings = { comments, emptyLines, brackets };
+    const startToken = tokens.copy();
+    const endToken = tokens.copy().stepToEof();
+    const { lineCount, currentToken } = countLines(startToken, endToken, settings);
     if (lineCount > maxLines) {
       report(`file contains more than ${maxLines} lines [${lineCount}].`, currentToken);
     }

--- a/src/rules/file-max-size.js
+++ b/src/rules/file-max-size.js
@@ -7,12 +7,8 @@ module.exports = {
     const maxLines = oldConfig ? options : options['max-lines'];
     const comments = oldConfig ? true : options['include-comments'];
     const emptyLines = oldConfig ? true : options['include-empty-lines'];
-    let brackets = oldConfig ? true : options['include-brackets'];
-    if (brackets === undefined) {
-      brackets = true; // Backwards compatibility
-    }
 
-    const settings = { comments, emptyLines, brackets };
+    const settings = { comments, emptyLines };
     const startToken = tokens.copy();
     const endToken = tokens.copy().stepToEof();
     const { lineCount, currentToken } = countLines(startToken, endToken, settings);

--- a/src/rules/file-max-size.js
+++ b/src/rules/file-max-size.js
@@ -1,5 +1,5 @@
 /* eslint no-continue: off */
-const { types } = require('../tokenize');
+const countLines = require('../line-count');
 
 module.exports = {
   check(options, tokens, report) {
@@ -9,24 +9,9 @@ module.exports = {
     const comments = oldConfig ? true : options['include-comments'];
     const emptyLines = oldConfig ? true : options['include-empty-lines'];
 
-    const lines = new Set();
-    while (tokens.type() !== types.eof) {
-      tokens.body().split(/\r?\n/).forEach((_, i) => {
-        if (tokens.type() === types.whitespace) {
-          return;
-        }
-        if ((tokens.type() === types.comments) && !comments) {
-          return;
-        }
-        lines.add(tokens.current().line + i);
-      });
-      tokens.step(false, comments || emptyLines);
-    }
-
-    tokens.step(true);
-    const lineCount = (emptyLines && comments) ? tokens.current().line : lines.size;
+    const { lineCount, currentToken } = countLines(tokens.copy(), { comments, emptyLines });
     if (lineCount > maxLines) {
-      report(`file contains more than ${maxLines} lines [${lineCount}].`, tokens.current());
+      report(`file contains more than ${maxLines} lines [${lineCount}].`, currentToken);
     }
   },
 };

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -97,6 +97,13 @@ class Tokens {
     return this;
   }
 
+  stepToEof() {
+    while (this.type() !== types.eof) {
+      this.step();
+    }
+    return this;
+  }
+
   /**
    * Steps to correct closing brace
    * @param  {tockensCallback} callback callback for each step

--- a/tests/rules/file-max-size.js
+++ b/tests/rules/file-max-size.js
@@ -36,7 +36,15 @@ ruleTest('file-max-size', rule, {
   valid: [
     {
       src,
-      config: 5,
+      config: 4,
+    },
+    {
+      src: src2,
+      config: 9,
+    },
+    {
+      src: src3,
+      config: 12,
     },
   ],
   invalid: [

--- a/tests/rules/file-max-size.js
+++ b/tests/rules/file-max-size.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line no-tabs
+// eslint-disable-file no-tabs
 const ruleTest = require('../../src/rule-test');
 const rule = require('../../src/rules/file-max-size');
 
@@ -33,11 +33,11 @@ const src3 = `<?php
  * comment
  */
    doSomething();
-			 	
-// This is a shorter comment
-   		 
-doSomethingElse();
 
+// This is a shorter comment
+		  
+doSomethingElse();
+		  
 if(true)
 {
   echo "hello world";

--- a/tests/rules/file-max-size.js
+++ b/tests/rules/file-max-size.js
@@ -18,6 +18,20 @@ one();
 two();
 `;
 
+const src3 = `<?php
+/**
+ * This is
+ * a very
+ * long
+ * comment
+ */
+   doSomething();
+
+// This is a shorter comment
+
+doSomethingElse();
+`;
+
 ruleTest('file-max-size', rule, {
   valid: [
     {
@@ -38,7 +52,7 @@ ruleTest('file-max-size', rule, {
         'include-comments': false,
         'include-empty-lines': true,
       },
-      messageIncludes: 'than 2 lines [7]',
+      messageIncludes: 'than 2 lines [5]',
     },
     {
       src: src2,
@@ -58,5 +72,23 @@ ruleTest('file-max-size', rule, {
       },
       messageIncludes: 'than 2 lines [9]',
     },
+    {
+      src: src3,
+      config: {
+        'max-lines': 2,
+        'include-comments': true,
+        'include-empty-lines': false,
+      },
+      messageIncludes: 'than 2 lines [10]',
+    },
+    {
+      src: src3,
+      config: {
+        'max-lines': 2,
+        'include-comments': false,
+        'include-empty-lines': true,
+      },
+      messageIncludes: 'than 2 lines [5]',
+    }
   ],
 });

--- a/tests/rules/file-max-size.js
+++ b/tests/rules/file-max-size.js
@@ -34,9 +34,9 @@ const src3 = `<?php
    doSomething();
 
 // This is a shorter comment
-
+			
 doSomethingElse();
-
+		    
 if(true)
 {
   echo "hello world";
@@ -123,6 +123,6 @@ ruleTest('file-max-size', rule, {
         'include-brackets': false,
       },
       messageIncludes: 'than 2 lines [15]',
-    },
+    }
   ],
 });

--- a/tests/rules/file-max-size.js
+++ b/tests/rules/file-max-size.js
@@ -89,6 +89,6 @@ ruleTest('file-max-size', rule, {
         'include-empty-lines': true,
       },
       messageIncludes: 'than 2 lines [5]',
-    }
+    },
   ],
 });

--- a/tests/rules/file-max-size.js
+++ b/tests/rules/file-max-size.js
@@ -1,4 +1,4 @@
-// eslint-disable-file no-tabs
+/* eslint-disable no-tabs */
 const ruleTest = require('../../src/rule-test');
 const rule = require('../../src/rules/file-max-size');
 

--- a/tests/rules/file-max-size.js
+++ b/tests/rules/file-max-size.js
@@ -18,6 +18,12 @@ one();
 two();
 `;
 
+/**
+ * 17 line breaks
+ * 7 comments
+ * 4 empty lines
+ * 2 brackets
+ */
 const src3 = `<?php
 /**
  * This is
@@ -30,6 +36,11 @@ const src3 = `<?php
 // This is a shorter comment
 
 doSomethingElse();
+
+if(true)
+{
+  echo "hello world";
+}
 `;
 
 ruleTest('file-max-size', rule, {
@@ -44,7 +55,12 @@ ruleTest('file-max-size', rule, {
     },
     {
       src: src3,
-      config: 12,
+      config: {
+        'max-lines': 17,
+        'include-empty-lines': true,
+        'include-comments': true,
+        'include-brackets': true,
+      },
     },
   ],
   invalid: [
@@ -87,7 +103,7 @@ ruleTest('file-max-size', rule, {
         'include-comments': true,
         'include-empty-lines': false,
       },
-      messageIncludes: 'than 2 lines [10]',
+      messageIncludes: 'than 2 lines [14]',
     },
     {
       src: src3,
@@ -96,7 +112,17 @@ ruleTest('file-max-size', rule, {
         'include-comments': false,
         'include-empty-lines': true,
       },
-      messageIncludes: 'than 2 lines [5]',
+      messageIncludes: 'than 2 lines [10]',
+    },
+    {
+      src: src3,
+      config: {
+        'max-lines': 2,
+        'include-comments': true,
+        'include-empty-lines': true,
+        'include-brackets': false,
+      },
+      messageIncludes: 'than 2 lines [15]',
     },
   ],
 });

--- a/tests/rules/file-max-size.js
+++ b/tests/rules/file-max-size.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-tabs
 const ruleTest = require('../../src/rule-test');
 const rule = require('../../src/rules/file-max-size');
 
@@ -32,11 +33,11 @@ const src3 = `<?php
  * comment
  */
    doSomething();
-
+			 	
 // This is a shorter comment
-			
+   		 
 doSomethingElse();
-		    
+
 if(true)
 {
   echo "hello world";
@@ -123,6 +124,6 @@ ruleTest('file-max-size', rule, {
         'include-brackets': false,
       },
       messageIncludes: 'than 2 lines [15]',
-    }
+    },
   ],
 });


### PR DESCRIPTION
The `file-max-size` rule contained a couple of errors, miscounting the actual lines. `comments` and `empty lines` aren't properly handled in combination with the `include-empty-lines` and `include-comments`. This is shown in a new test, which fails without the fix. This PR fixes these settings.